### PR TITLE
Prevent duplicate db entries

### DIFF
--- a/src/api/authors/controllers/AuthorController.ts
+++ b/src/api/authors/controllers/AuthorController.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Hidden, Post, Route, Tags } from "tsoa";
+import { Body, Controller, Post, Route, Tags } from "tsoa";
 import { CreateAuthorInput } from "../entities/CreateAuthorInput";
 import Author from "../models/Author";
 import RealAuthorService from "../services/AuthorService";
@@ -7,7 +7,6 @@ import RealAuthorService from "../services/AuthorService";
 @Tags("Author")
 export class AuthorController extends Controller {
   /** Create author */
-  @Hidden()
   @Post()
   async createAuthor(@Body() input: CreateAuthorInput): Promise<Author> {
     return await new RealAuthorService().createAuthor(input);

--- a/src/api/authors/services/createAuthor.ts
+++ b/src/api/authors/services/createAuthor.ts
@@ -1,3 +1,4 @@
+import { ObjectAlreadyExists } from "../../../errors";
 import { AuthorModel } from "../../../models";
 import { CreateAuthorInput } from "../entities/CreateAuthorInput";
 import Author from "../models/Author";
@@ -5,6 +6,10 @@ import Author from "../models/Author";
 export default async function createAuthor(input: CreateAuthorInput): Promise<Author> {
   try {
     const { firstName, lastName } = input;
+
+    if (await AuthorModel.exists({firstName: firstName, lastName: lastName})) {
+      throw new ObjectAlreadyExists();
+    }
 
     return await AuthorModel.create({ firstName, lastName });
   } catch (error) {

--- a/src/api/books/services/createBook.ts
+++ b/src/api/books/services/createBook.ts
@@ -11,9 +11,10 @@ export default async function createBook(
   coverImage?: string
 ): Promise<DocumentType<Book>> {
   try {
-    if (BookModel.exists({"googleId": googleId})) {
+    if (await BookModel.exists({googleId: googleId})) {
       throw new ObjectAlreadyExists();
     }
+
     return await BookModel.create({
       googleId,
       title,

--- a/src/api/books/services/createBook.ts
+++ b/src/api/books/services/createBook.ts
@@ -1,4 +1,5 @@
 import { DocumentType } from "@typegoose/typegoose";
+import { ObjectAlreadyExists } from "../../../errors";
 import { BookModel } from "../../../models";
 import Book from "../models/Book";
 
@@ -10,6 +11,9 @@ export default async function createBook(
   coverImage?: string
 ): Promise<DocumentType<Book>> {
   try {
+    if (BookModel.exists({"googleId": googleId})) {
+      throw new ObjectAlreadyExists();
+    }
     return await BookModel.create({
       googleId,
       title,

--- a/src/api/booktags/services/createBookTag.ts
+++ b/src/api/booktags/services/createBookTag.ts
@@ -1,9 +1,14 @@
 import { DocumentType } from "@typegoose/typegoose";
+import { RelationshipAlreadyExists } from "../../../errors";
 import { BookTagModel } from "../../../models";
 import BookTag from "../models/BookTag";
 
 export default async function createBookTag(bookId: string, tagId: string, userId: string): Promise<DocumentType<BookTag>> {
   try {
+    if (await BookTagModel.exists({bookId: bookId, tagId: tagId})) {
+      throw new RelationshipAlreadyExists();
+    }
+
     return await BookTagModel.create({ bookId, tagId, userAddedById: userId });
   } catch (error) {
     throw error;

--- a/src/api/tags/services/createTag.ts
+++ b/src/api/tags/services/createTag.ts
@@ -1,3 +1,4 @@
+import { ObjectAlreadyExists } from "../../../errors";
 import { TagModel } from "../../../models";
 import { CreateTagInput } from "../entities/CreateTagInput";
 import Tag from "../models/Tag";
@@ -5,6 +6,10 @@ import Tag from "../models/Tag";
 export default async function createTag(input: CreateTagInput): Promise<Tag> {
   try {
     const { tag } = input;
+
+    if (await TagModel.exists({tag: tag})) {
+      throw new ObjectAlreadyExists();
+    }
 
     return await TagModel.create({ tag });
   } catch (error) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -230,3 +230,15 @@ export class CommentUpvoteNotFound implements DropboxReadsError {
     this.type = this.constructor.name;
   }
 }
+
+export class ObjectAlreadyExists implements DropboxReadsError {
+  readonly message?: string = "Comment upvote not found";
+  readonly error?: any;
+  readonly type: string;
+
+  constructor(message?: string, error?: any) {
+    this.message = message;
+    this.error = error;
+    this.type = this.constructor.name;
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -232,7 +232,7 @@ export class CommentUpvoteNotFound implements DropboxReadsError {
 }
 
 export class ObjectAlreadyExists implements DropboxReadsError {
-  readonly message?: string = "Comment upvote not found";
+  readonly message?: string = "Object already exists";
   readonly error?: any;
   readonly type: string;
 


### PR DESCRIPTION
## Changes
* Make the authors endpoint visible in tsoa documentation
* Throw an `ObjectAlreadyExists` or `RelationshipAlreadyExists` error if a new object/relationship with the same identifying properties as what exists in the db is attempted to be created. This enforcement is applied to:
    * BookTags
    * Books
    * Authors
    * Tags
    * Upvotes
They properties for the above are currently case sensitive.

## Test plan
* Hit `/tags` and create a new tag that doesn't exist in db yet
* Attempt to create the same tag a second time => error