### PR TITLE
Basic book search endpoint

### DIFF
--- a/src/api/books/services/BookService.ts
+++ b/src/api/books/services/BookService.ts
@@ -8,6 +8,7 @@ import addBookUpvote from "./addBookUpvote";
 import createBook from "./createBook";
 import getGodBookById from "./getGodBookById";
 import addComment from "./addComment";
+import getBooksMatchingKeyword from "./getBooksMatchingKeyword";
 
 interface BookService {
   createBook(googleId: string, title: string, authorId: string, userId: string, coverImage?: string): Promise<DocumentType<Book>>;
@@ -17,6 +18,7 @@ interface BookService {
   getGodBookById(bookId: string): Promise<GodBook>;
   addBookUpvote(bookId: string, upvoteId: string): Promise<void>;
   addComment(bookId: string, commentId: string): Promise<void>;
+  getBooksMatchingKeyword(keyword: string): Promise<GodBook[]>;
 }
 
 export default class RealBookService implements BookService {
@@ -52,5 +54,9 @@ export default class RealBookService implements BookService {
 
   public async addComment(bookId: string, commentId: string): Promise<void> {
     return await addComment(bookId, commentId);
+  }
+
+  public async getBooksMatchingKeyword(keyword: string): Promise<GodBook[]> {
+    return await getBooksMatchingKeyword(keyword);
   }
 }

--- a/src/api/books/services/BookService.ts
+++ b/src/api/books/services/BookService.ts
@@ -18,7 +18,7 @@ interface BookService {
   getGodBookById(bookId: string): Promise<GodBook>;
   addBookUpvote(bookId: string, upvoteId: string): Promise<void>;
   addComment(bookId: string, commentId: string): Promise<void>;
-  getBooksMatchingKeyword(keyword: string): Promise<GodBook[]>;
+  getBooksMatchingKeyword(keyword?: string, title?: string, author?: string, tags?: string[]): Promise<GodBook[]>;
 }
 
 export default class RealBookService implements BookService {
@@ -56,7 +56,7 @@ export default class RealBookService implements BookService {
     return await addComment(bookId, commentId);
   }
 
-  public async getBooksMatchingKeyword(keyword: string): Promise<GodBook[]> {
-    return await getBooksMatchingKeyword(keyword);
+  public async getBooksMatchingKeyword(keyword?: string, title?: string, author?: string, tags?: string[]): Promise<GodBook[]> {
+    return await getBooksMatchingKeyword(keyword, title, author, tags);
   }
 }

--- a/src/api/books/services/getBooksMatchingKeyword.ts
+++ b/src/api/books/services/getBooksMatchingKeyword.ts
@@ -2,6 +2,7 @@ import { BookModel } from "../../../models";
 import { GodBook } from "../../books/models/GodBook";
 
 export default async function getBooksMatchingKeyword(keyword: string): Promise<GodBook[]> {
+    // Search in book title, book author, and book tag fields
     const matchingTitles = await BookModel.find({title: {$regex: keyword, $options: 'i'}});
     const books = [];
     for (const title of matchingTitles) {

--- a/src/api/books/services/getBooksMatchingKeyword.ts
+++ b/src/api/books/services/getBooksMatchingKeyword.ts
@@ -1,0 +1,11 @@
+import { BookModel } from "../../../models";
+import { GodBook } from "../../books/models/GodBook";
+
+export default async function getBooksMatchingKeyword(keyword: string): Promise<GodBook[]> {
+    const matchingTitles = await BookModel.find({title: {$regex: keyword, $options: 'i'}});
+    const books = [];
+    for (const title of matchingTitles) {
+        books.push(await title.toGodBook());
+    }
+    return books;
+}

--- a/src/api/books/services/getBooksMatchingKeyword.ts
+++ b/src/api/books/services/getBooksMatchingKeyword.ts
@@ -1,12 +1,15 @@
 import { BookModel } from "../../../models";
 import { GodBook } from "../../books/models/GodBook";
 
-export default async function getBooksMatchingKeyword(keyword: string): Promise<GodBook[]> {
+export default async function getBooksMatchingKeyword(keyword?: string, title?: string, author?: string, tags?: string[]): Promise<GodBook[]> {
     // Search in book title, book author, and book tag fields
     const matchingTitles = await BookModel.find({title: {$regex: keyword, $options: 'i'}});
     const books = [];
     for (const title of matchingTitles) {
         books.push(await title.toGodBook());
     }
+    title;
+    author;
+    tags;
     return books;
 }

--- a/src/api/comments/models/GodComment.ts
+++ b/src/api/comments/models/GodComment.ts
@@ -55,7 +55,7 @@ export class RealGodComment implements GodComment {
       this.user = (comment.userId as DocumentType<User>).toSafeUser();
       this.review = comment.reviewId as DocumentType<Review>;
 
-      this.parentComment = await (comment.parentCommentId as DocumentType<Comment>).toGodComment();
+      if (comment.parentCommentId) this.parentComment = await (comment.parentCommentId as DocumentType<Comment>).toGodComment();
 
       const childrenComments = [];
 
@@ -68,7 +68,7 @@ export class RealGodComment implements GodComment {
       this.commentUpvotes = comment.commentUpvoteIds as DocumentType<CommentUpvote>[];
       this.commentReactions = comment.commentReactionIds as DocumentType<CommentReaction>[];
 
-      this.book = await (comment.bookId as DocumentType<Book>).toGodBook();
+      if (comment.bookId) this.book = await (comment.bookId as DocumentType<Book>).toGodBook();
     } catch (error) {
       throw error;
     }

--- a/src/api/search/controllers/SearchController.ts
+++ b/src/api/search/controllers/SearchController.ts
@@ -1,13 +1,14 @@
 import RealBookService from "../../books/services/BookService";
-import { Controller, Get, Path, Route, Tags } from "tsoa";
+import { Body, Controller, Post, Route, Tags } from "tsoa";
 import { GodBook } from "../../books/models/GodBook";
+import SearchInput from "../entities/SearchInput";
 
 @Route("search")
 @Tags("Search")
 export class SearchController extends Controller {
-    
-  @Get("{keyword}")
-  async search(@Path() keyword: string): Promise<GodBook[]> {
-    return await new RealBookService().getBooksMatchingKeyword(keyword);
+  @Post()
+  async search(@Body() input: SearchInput): Promise<GodBook[]> {
+    const { keyword, title, author, tags } = input;
+    return await new RealBookService().getBooksMatchingKeyword(keyword, title, author, tags);
   }
 }

--- a/src/api/search/controllers/SearchController.ts
+++ b/src/api/search/controllers/SearchController.ts
@@ -1,0 +1,13 @@
+import RealBookService from "../../books/services/BookService";
+import { Controller, Get, Path, Route, Tags } from "tsoa";
+import { GodBook } from "../../books/models/GodBook";
+
+@Route("search")
+@Tags("Search")
+export class SearchController extends Controller {
+  /** Search in book author, title, and tag fields */
+  @Get("{keyword}")
+  async search(@Path() keyword: string): Promise<GodBook[]> {
+    return await new RealBookService().getBooksMatchingKeyword(keyword);
+  }
+}

--- a/src/api/search/controllers/SearchController.ts
+++ b/src/api/search/controllers/SearchController.ts
@@ -5,7 +5,7 @@ import { GodBook } from "../../books/models/GodBook";
 @Route("search")
 @Tags("Search")
 export class SearchController extends Controller {
-  /** Search in book author, title, and tag fields */
+    
   @Get("{keyword}")
   async search(@Path() keyword: string): Promise<GodBook[]> {
     return await new RealBookService().getBooksMatchingKeyword(keyword);

--- a/src/api/search/entities/SearchInput.ts
+++ b/src/api/search/entities/SearchInput.ts
@@ -1,0 +1,6 @@
+export default interface SearchInput {
+    keyword?: string,
+    title?: string,
+    author?: string,
+    tags?: string[],
+}


### PR DESCRIPTION
## Changes
* Protection against `undefined` in conversion of comment -> godcomment
* Basic search endpoint (on searches on book title for now)

## Test Plan
* Hit `v1/search` with
```
{
    "keyword": "the"
}
```
* All "The Rebel" entries come up
* Hit `v1/search`
```
{
    "keyword": "rebel"
}
```
* "The Rebel" entries come up
* Hit `v1/search`
```
{
    "keyword": "apple"
}
```
* Empty array is returned